### PR TITLE
transfert-time argument implemented.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache: cargo
 before_script:
-  - cargo install -f rustfmt
+  - cargo install -f rustfmt --vers 0.7.1  # the 0.8.0 is buggy, for the moment we fix the version
   - export PATH=$PATH:$HOME/.cargo/bin
 rust:
   - stable

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ struct Args {
                         You may want to divide your initial speed by \
                         sqrt(2) to simulate Manhattan distances")]
     walking_speed: f64,
+
+    #[structopt(long = "transfer-time", short = "t", default_value = "0",
+                help = "Transfer time in second.")]
+    transfer_time: u32,
 }
 
 #[derive(Debug)]
@@ -138,7 +142,7 @@ fn main() {
                 wtr.encode((&stop_point_1.stop_id,
                              &stop_point_2.stop_id,
                              2,
-                             (distance / args.walking_speed) as u32))
+                             ((distance / args.walking_speed) as u32) + args.transfer_time))
                     .unwrap();
             }
         }


### PR DESCRIPTION
# Description

This PR resolve this https://github.com/CanalTP/transfe_rs/issues/3

`--transfer-time` option added

```
OPTIONS:
    -t, --transfer-time <transfer_time>    The transfer time in second. [default: 120]

```

# How to test it ?

Without this option (default value)
```
from_stop_id,to_stop_id,transfer_type,min_transfer_time
StopPoint:OIF86:319,StopPoint:OIF86:319,2,120
```

With this option `--transfer-time 42`
```
from_stop_id,to_stop_id,transfer_type,min_transfer_time
StopPoint:OIF86:319,StopPoint:OIF86:319,2,42
```